### PR TITLE
[FIX] Manifest: Move test asset declaration

### DIFF
--- a/web_widget_markdown/__manifest__.py
+++ b/web_widget_markdown/__manifest__.py
@@ -22,8 +22,10 @@
         "web.assets_qweb": [
             "/web_widget_markdown/static/src/xml/qweb_template.xml",
         ],
-        "web.qunit_suite_tests": [
+        "web.tests_assets": [
             "/web_widget_markdown/static/lib/simplemde.min.js",
+        ],
+        "web.qunit_suite_tests": [
             "/web_widget_markdown/static/tests/**/*",
         ],
     },


### PR DESCRIPTION
Without this, tests break on a recent Odoo 16.0.

Inspired by `partner_autocomplete` in Odoo where the `jsvat` lib is similarly lazy-loaded.